### PR TITLE
[mail < 100-remove-version-from-docker-compose-yml] Remove version from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   memgraph:
     image: memgraph/memgraph-mage:latest


### PR DESCRIPTION
Removec `version` from `docker-compose.yml` since it is obsolete now.